### PR TITLE
Reactivate VirtualPlanet server and update metadata

### DIFF
--- a/inactive.json
+++ b/inactive.json
@@ -250,7 +250,6 @@
     "vytrexpvp",
     "xlzpvp",
     "yolomc",
-    "virtualplanet",
     "zetta",
     "magiccraft2",
     "zyro",

--- a/servers/virtualplanet/metadata.json
+++ b/servers/virtualplanet/metadata.json
@@ -1,22 +1,28 @@
 {
     "id": "virtualplanet",
     "name": "VirtualPlanet",
-    "store": "https://tienda.virtualplanet.es/",
+    "description": "Spanish survival server offering a classic Minecraft experience.",
     "addresses": [
         "virtualplanet.es"
     ],
     "primaryAddress": "mc.virtualplanet.es",
-    "primaryColor": "#f1db81",
-    "secondaryColor": "#d57d47",
     "minecraftVersions": [
         "1.8.*",
         "1.12.*",
         "1.16.*",
         "1.17.*",
         "1.18.*",
-        "1.19.*"
+        "1.19.*",
+        "1.20.*",
+        "1.21.*"
     ],
     "primaryMinecraftVersion": "1.8.9",
+    "primaryColor": "#f1db81",
+    "secondaryColor": "#d57d47",
+    "primaryLanguage": "es-EN",
+    "languages": [
+        "es-EN"
+    ],
     "primaryRegion": "EU",
     "regions": [
         "EU"
@@ -24,6 +30,14 @@
     "gameTypes": [
         "Survival"
     ],
+    "website": "https://virtualplanet.es",
+    "store": "https://tienda.virtualplanet.es/",
+    "compliance": {
+        "privacyPolicy": "https://virtualplanet.es/legal/politica-de-privacidad",
+        "termsOfService": "https://virtualplanet.es/legal/terminos-de-servicio",
+        "rules": "https://virtualplanet.es/normativa",
+        "support": "https://virtualplanet.es/discord"
+    },
     "socials": {
         "twitter": "VirtualPlanetNT",
         "discord": "https://discord.com/invite/fwPuWPw",


### PR DESCRIPTION
## Summary

Reactivates the `virtualplanet` server (previously marked inactive) and updates its metadata with current information. The server is active again and online at `mc.virtualplanet.es`.

## Changes

- Remove `virtualplanet` from `inactive.json`
- `servers/virtualplanet/metadata.json`:
  - Added `description`, `website`, `primaryLanguage`, `languages`, `compliance`
  - Updated `minecraftVersions` to include `1.20.*` and `1.21.*`
  - Reordered fields to match `metadata.example.json`

---

### General:

-   [x] The pull request title is descriptive. _(ex. `Added Lunar Network`, not `Updated metadata.json`)_
-   [x] The pull request does not contain any unrelated commits. _(ex. commits from previous pull requests)_

### Mapping Additions or Updates:

-   [x] Folder with appropriate name has been created / updated (must not include any non-alpha characters or whitespace).
-   [x] No changes were made to the file's formatting (4 spaces per tab).
-   [x] There are no syntax errors.
-   [x] There is no pre-existing mapping matching my id (check if there is an existing folder).
-   [x] My field values match your requirements.
-   You can view our patterns here: [metadata.schema.json](https://github.com/LunarClient/ServerMappings/blob/master/metadata.schema.json), or take a look below and complete the field checklist:
    -   [x] `id`: a lowercase string, which should match the folder name _(ex. `myserver`)_
    -   [x] `name`: a string _(ex. `MyServerPvP`)_
    -   [x] `description`: hook between 16 and 80 characters in English _(ex. `Home of Competitive Minecraft PvP`)_
    -   [x] `addresses`: an array with lowercase strings _(ex. `["my.server", "your-server.com"]`)_
        -   You do not need to specify subdomains, Lunar Client services automatically detect them.
    -   [x] `primaryAddress`: the primary address that people connect to with (please include the subdomain if required) _(ex. `mc.my.server`)_
    -   [x] `minecraftVersions`: an array with Minecraft versions as strings _(ex. `["1.18._", "1.19.2"]` - Must be versions or subversions supported by Lunar Client)\*
    -   [x] `primaryMinecraftVersion`: a Minecraft version as a string _(ex. `1.19.2` - Must be a subversion supported by Lunar Client)_
    -   [x] `primaryColor`: a hexademical color code that primarily distinguishes the server _(ex. `#00FFFF`)_
    -   [x] `secondaryColor`: a hexademical color code that accompanies the `primaryColor` of the server _(ex. `#FF0000`)_
    -   [x] `primaryRegion`: the primary region where your server operates in _(ex. `NA`)_
    -   [x] `regions`: a list of regions where you have servers located that service your players _(ex. `["NA", "EU", "AS"]`)_
    -   [x] `gameTypes`: a list of games that describe the content on your server, must be a max of 3 listed _(ez. `["PVP", "UHC", "HCF"]`)_
    -   [ ] `crossplay`: whether the server has support for Bedrock Edition players (through proxies such as [GeyserMC](https://geysermc.org/))
    -   [ ] (optional) `presentationVideo`: YouTube video ID (in slug) to server trailer / introduction _(ex. `7EV4cPuJvXE`)_
    -   [ ] (optional) `votingLinks`: an array of urls to your server's listing on voting websites _(ex. `["https://minecraft-mp.com/server-s179012"]`)_
    -   [x] (optional) `website`: url of server website, must include URL schema (http:// or https://) _(ex. `https://www.your-server.com`)_
    -   [x] (optional) `store`: url of server store, must include URL schema (http:// or https://) _(ex. `https://store.your-server.com`)_
    -   [ ] (optional) `wiki`: url of server wiki, must include URL schema (http:// or https://) _(ex. `https://wiki.your-server.com`)_
    -   [ ] (optional) `merch`: url of server merchanise site (if seperate from store), must include URL schema (http:// or https://) _(ex. `https://merch.your-server.com`)_

### Socials

-   [x] (optional) `twitter`: username of twitter account without the @ _(ex. MyServer)_
-   [x] (optional) `discord`: invite link to discord _(ex. https://discord.com/invite/4ceEJuH)_
-   [ ] (optional) `youtube`: slug or username of youtube channel _(ex. MyServer)_
-   [ ] (optional) `instagram`: username of instagram account _(ex. MyServer)_
-   [ ] (optional) `twitch`: username of twitch account _(ex. MyServer)_
-   [ ] (optional) `telegram`: slug of telegram group _(ex. MyServer)_
-   [ ] (optional) `reddit`: slug of subdreddit wtih 'r/' _(ex. MyServer)_
-   [ ] (optional) `tiktok`: username of tiktok account _(ex. MyServer)_
-   [x] (optional) `facebook`: slug of facebook page _(ex. MyServer)_

### Compliance

-   [x] (optional) `privacyPolicy`: url to your Privacy Policy _(ex. https://www.lunar.gg/privacy)_
-   [x] (optional) `termsOfService`: url to your Terms of Service _(ex. https://www.lunar.gg/terms)_
-   [x] (optional) `rules`: url to your Rules _(ex. https://www.lunar.gg/rules)_
-   [x] (optional) `support`: url to your Support Site _(ex. https://www.lunar.gg/support)_

### Media:

#### Logo

-   [x] My logo is a `png` file.
-   [x] I have uploaded my logo to my server folder _(ex. `lunarnetwork`)_ and named it `logo.png`.
-   [x] My logo has a transparent background and is square (1:1 aspect ratio).
-   [x] My logo is at least `512` pixels in width and height.
-   [x] My logo is my own property and complies with relevant copyright/privacy laws.
-   [x] My logo is not upscaled from a smaller low quality image.

#### Background

-   [x] My background is a `png` file.
-   [x] I have uploaded my background to my server folder _(ex. `lunarnetwork`)_ and named it `background.png`.
-   [x] My background has an aspect ratio of 16:9.
-   [x] My background is atleast `1920` pixels in width and `1080` pixels in height (can be bigger, but must remain the same aspect ratio).
-   [x] My background contains relevant content pertaining to the server, is my own property, and complies with relevant copyright/privacy laws.
-   [x] My background doesn't contain any markings, text, or logos (unless part of a build).