### PR TITLE
chore: update Mineplex's supported minecraft versions

### DIFF
--- a/servers/mineplex/metadata.json
+++ b/servers/mineplex/metadata.json
@@ -12,14 +12,9 @@
     "primaryColor": "#f38910",
     "secondaryColor": "#38b1dc",
     "minecraftVersions": [
-        "1.8.*",
-        "1.12.*",
-        "1.16.*",
-        "1.17.*",
-        "1.18.*",
-        "1.19.*",
-        "1.20.*",
-        "1.21.*"
+        "1.8.9",
+        "1.21.11",
+        "26.*"
     ],
     "primaryMinecraftVersion": "1.8.9",
     "crossplay": true,


### PR DESCRIPTION
Mineplex now only supports 1.8.9, 1.21.11 and 26+
<img width="852" height="515" alt="image" src="https://github.com/user-attachments/assets/f513afba-5d59-45ef-9992-57122f2f9939" />
