### PR TITLE
feat: mark ClownMC and StarryMC as inactive

### DIFF
--- a/inactive.json
+++ b/inactive.json
@@ -274,5 +274,7 @@
     "septrux",
     "fantamc",
     "starsmp",
-    "smitesmp"
+    "smitesmp",
+    "clownmc",
+    "starrymc"
 ]


### PR DESCRIPTION
Marks clownmc and starrymc as inactive in inactive.json as both servers have been shut down for more than 3 months.