### PR TITLE
feat: add modpack provider field (modrinth/curseforge)

### DIFF
--- a/metadata.schema.json
+++ b/metadata.schema.json
@@ -126,13 +126,19 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                "provider": {
+                    "type": "string",
+                    "enum": ["modrinth", "curseforge"],
+                    "default": "modrinth",
+                    "description": "The platform hosting the modpack. If blank, defaults to Modrinth."
+                },
                 "id": {
                     "type": "string",
-                    "description": "The Modrinth Modpack ID."
+                    "description": "The Modpack ID on the given provider (Modrinth project ID or CurseForge mod ID)."
                 },
                 "recommendedVersion": {
                     "type": "string",
-                    "description": "The recommended Modrinth Modpack version. If blank, will use latest version."
+                    "description": "The recommended Modpack version. If blank, will use latest version."
                 },
                 "recommendedReleaseChannel": {
                     "type": "string",


### PR DESCRIPTION
adds a `provider` field (`modrinth` | `curseforge`, defaults to `modrinth`) to the `modpack` object in `metadata.schema.json` so a server can recommend a curseforge modpack, not just modrinth.

`modpack.additionalProperties` is `false`, so the field has to be in the schema before any server can set it — the validator (`.scripts/validate.py`) is schema-driven, no code change needed.

also softened the modrinth-only wording on `id`/`recommendedVersion` since they now depend on the provider. `id` stays the only required field (provider defaults to modrinth), so every existing server keeps validating unchanged.



follow-up: document the modpack object + provider in `docs/adding-servers/metadata.mdx` (currently undocumented)
