### PR TITLE
fix(mindgames): set curseforge provider for modpack

### DIFF
--- a/servers/mindgames/metadata.json
+++ b/servers/mindgames/metadata.json
@@ -43,6 +43,7 @@
         "support": "https://discord.gg/mindofneo"
     },
     "modpack": {
+        "provider": "curseforge",
         "id": "1622906",
         "promptBeforeGameJoin": true,
         "promptBeforeLauncherJoin": true


### PR DESCRIPTION
## Problem

f41c5da added a `modpack` section for Mind Games with id `1622906`, but omitted the `provider` field. The provider defaults to Modrinth, and `1622906` is a **CurseForge** modpack ID (https://www.curseforge.com/minecraft/modpacks/mindgames) — Modrinth returns 404 for it.

As a result, the launcher's "Play with Modpack" prompt shows **"recommends Minecraft 1.21.11 with 0 mods"**, and installing the modpack fails since it's looked up on the wrong platform.

## Fix

Set `"provider": "curseforge"` on the Mind Games modpack entry.