### PR TITLE
Update Unity SMP domain

### DIFF
--- a/servers/unitysmp/metadata.json
+++ b/servers/unitysmp/metadata.json
@@ -3,9 +3,9 @@
   "name": "Unity SMP",
   "description": "A friendly crossplay survival server with economy and teams.",
   "addresses": [
-    "brads-lab.com"
+    "unity-smp.com"
   ],
-  "primaryAddress": "play.brads-lab.com",
+  "primaryAddress": "unity-smp.com",
   "minecraftVersions": [
     "1.8.*",
     "1.12.*",


### PR DESCRIPTION
## What changed

- Replaced the legacy `brads-lab.com` server mapping with `unity-smp.com`.
- Set `unity-smp.com` as Unity SMP's primary address.

## Why

Unity SMP has moved to its dedicated domain, and this keeps Lunar Client's server recognition aligned with the address players will use.

## Validation

- Ran the repository's full metadata and media validator successfully.
- Confirmed the change is limited to `servers/unitysmp/metadata.json`.
