### PR TITLE
Upload CDN assets to R2 instead of GCS

### DIFF
--- a/.github/workflows/validate-upload.yml
+++ b/.github/workflows/validate-upload.yml
@@ -95,29 +95,29 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      id-token: write
       contents: read
+
+    env:
+      AWS_ENDPOINT_URL: ${{ secrets.CF_R2_ENDPOINT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: auto
 
     steps:
       - name: Checkout from GitHub
         uses: actions/checkout@v4
 
-      - name: Configure Google Cloud credentials
-        uses: google-github-actions/auth@v3
-        with:
-          workload_identity_provider: 'projects/824216268633/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc'
-          service_account: "github-actions@mw-lunarclient-cdn.iam.gserviceaccount.com"
-
       - name: Refuse to publish an older index
         run: |
           SOURCE_COMMITTED_AT="$(date -u -d "$(git show -s --format=%cI HEAD)" +%Y-%m-%dT%H:%M:%SZ)"
 
-          if ! LIVE_METADATA="$(gcloud storage objects describe gs://servermappings-lunarclientcdn-com/servers.json --raw --format=json)"; then
+          if ! LIVE_METADATA="$(aws s3api head-object --bucket servermappings-lunarclientcdn-com --key servers.json)"; then
             echo "::error::Unable to read metadata of the published servers.json."
             exit 1
           fi
 
-          LIVE_COMMITTED_AT="$(printf '%s' "$LIVE_METADATA" | python3 -c 'import json, sys; print(json.load(sys.stdin).get("metadata", {}).get("sourceCommittedAt", ""))')"
+          # S3 lowercases user metadata keys
+          LIVE_COMMITTED_AT="$(printf '%s' "$LIVE_METADATA" | python3 -c 'import json, sys; print(json.load(sys.stdin).get("Metadata", {}).get("sourcecommittedat", ""))')"
 
           if [ -z "$LIVE_COMMITTED_AT" ]; then
             echo "::warning::Published servers.json has no sourceCommittedAt; skipping freshness check."
@@ -196,19 +196,19 @@ jobs:
           CROWDIN_PROJECT_ID: "424304"
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_TOKEN }}
 
-      - name: Upload to GCS
+      - name: Upload to R2
         run: |
           SOURCE_COMMITTED_AT="$(date -u -d "$(git show -s --format=%cI HEAD)" +%Y-%m-%dT%H:%M:%SZ)"
           cd .out/
-          gcloud storage cp --recursive --cache-control='public, max-age=3600, s-maxage=3600' backgrounds/ gs://servermappings-lunarclientcdn-com/ || true
-          gcloud storage cp --recursive --cache-control='public, max-age=3600, s-maxage=3600' banners/ gs://servermappings-lunarclientcdn-com/ || true
-          gcloud storage cp --recursive --cache-control='public, max-age=3600, s-maxage=3600' logos/ gs://servermappings-lunarclientcdn-com/ || true
-          gcloud storage cp --recursive --cache-control='public, max-age=3600, s-maxage=3600' wordmarks/ gs://servermappings-lunarclientcdn-com/ || true
-          gcloud storage cp \
-            --cache-control='public, max-age=300, s-maxage=300' \
-            --custom-metadata="sourceCommittedAt=${SOURCE_COMMITTED_AT}" \
-            servers.json gs://servermappings-lunarclientcdn-com/servers.json
-          gcloud storage cp --recursive --cache-control='public, max-age=31536000, s-maxage=31536000' assets/ gs://servermappings-lunarclientcdn-com/ || true
+          aws s3 cp --recursive --cache-control 'public, max-age=3600, s-maxage=3600' backgrounds/ s3://servermappings-lunarclientcdn-com/backgrounds/ || true
+          aws s3 cp --recursive --cache-control 'public, max-age=3600, s-maxage=3600' banners/ s3://servermappings-lunarclientcdn-com/banners/ || true
+          aws s3 cp --recursive --cache-control 'public, max-age=3600, s-maxage=3600' logos/ s3://servermappings-lunarclientcdn-com/logos/ || true
+          aws s3 cp --recursive --cache-control 'public, max-age=3600, s-maxage=3600' wordmarks/ s3://servermappings-lunarclientcdn-com/wordmarks/ || true
+          aws s3 cp \
+            --cache-control 'public, max-age=300, s-maxage=300' \
+            --metadata "sourceCommittedAt=${SOURCE_COMMITTED_AT}" \
+            servers.json s3://servermappings-lunarclientcdn-com/servers.json
+          aws s3 cp --recursive --cache-control 'public, max-age=31536000, s-maxage=31536000' assets/ s3://servermappings-lunarclientcdn-com/assets/ || true
 
       - name: Purge Cloudflare cache
         env:


### PR DESCRIPTION
Part of the GCS→R2 CDN migration. The `servermappings-lunarclientcdn-com` R2 bucket exists and its data has been copied from GCS with per-object Cache-Control preserved.

- `gcloud storage cp` → `aws s3 cp` against R2, keeping the exact same per-path Cache-Control values (3600 for media, 300 for servers.json, 1yr for assets/)
- The stale-index guard now reads `sourceCommittedAt` via `aws s3api head-object` (S3 lowercases user metadata keys)
- Google auth + `id-token` dropped — nothing else in the job uses GCP
- Explicit destination prefixes because `aws s3 cp --recursive dir/` doesn't recreate the source directory name like gcloud does

⚠️ Merge only when instructed — needs the CF_R2_* org secrets granted to this repo first, and a final delta sync of the bucket right before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)