### PR TITLE
feat: Update Craftok

### DIFF
--- a/servers/craftok/metadata.json
+++ b/servers/craftok/metadata.json
@@ -3,7 +3,7 @@
     "name": "Craftok",
     "website": "https://craftok.fr",
     "store": "https://store.craftok.fr",
-    "description": "A French Minigames server: BedWars, KitPvP, Ranked Duels & more!",
+    "description": "A French Minigames server: BedWars, PartyGames, Ranked Duels & more!",
     "addresses": [
         "craftok.fr",
         "crafttok.fr"
@@ -19,7 +19,9 @@
         "1.18.*",
         "1.19.*",
         "1.20.*",
-        "1.21.*"
+        "1.21.*",
+        "26.1.*",
+        "26.2.*"
     ],
     "primaryMinecraftVersion": "1.8.9",
     "primaryRegion": "EU",
@@ -28,12 +30,12 @@
     ],
     "primaryLanguage": "fr",
     "languages": [
-        "fr"
+        "fr",
+        "en"
     ],
     "gameTypes": [
         "PvP",
-        "Minigames",
-        "UHC"
+        "Minigames"
     ],
     "socials": {
         "twitter": "CraftokMC",

--- a/servers/craftok/metadata.json
+++ b/servers/craftok/metadata.json
@@ -4,6 +4,7 @@
     "website": "https://craftok.fr",
     "store": "https://store.craftok.fr",
     "description": "A French Minigames server: BedWars, PartyGames, Ranked Duels & more!",
+    "crossplay": false,
     "addresses": [
         "craftok.fr",
         "crafttok.fr"


### PR DESCRIPTION
Updated the server description and added English to the supported languages. Included additional Minecraft versions.

### General:

-   [X] The pull request title is descriptive. _(ex. `Added Lunar Network`, not `Updated metadata.json`)_
-   [X] The pull request does not contain any unrelated commits. _(ex. commits from previous pull requests)_

### Mapping Additions or Updates:

-   [X] Folder with appropriate name has been created / updated (must not include any non-alpha characters or whitespace).
-   [X] No changes were made to the file's formatting (4 spaces per tab).
-   [X] There are no syntax errors.
-   [X] There is no pre-existing mapping matching my id (check if there is an existing folder).
-   [X] My field values match your requirements.
-   You can view our patterns here: [metadata.schema.json](https://github.com/LunarClient/ServerMappings/blob/master/metadata.schema.json), or take a look below and complete the field checklist:
    -   [X] `id`: a lowercase string, which should match the folder name _(ex. `myserver`)_
    -   [X] `name`: a string _(ex. `MyServerPvP`)_
    -   [X] `description`: hook between 16 and 80 characters in English _(ex. `Home of Competitive Minecraft PvP`)_
    -   [X] `addresses`: an array with lowercase strings _(ex. `["my.server", "your-server.com"]`)_
        -   You do not need to specify subdomains, Lunar Client services automatically detect them.
    -   [X] `primaryAddress`: the primary address that people connect to with (please include the subdomain if required) _(ex. `mc.my.server`)_
    -   [X] `minecraftVersions`: an array with Minecraft versions as strings _(ex. `["1.18._", "1.19.2"]` - Must be versions or subversions supported by Lunar Client)\*
    -   [X] `primaryMinecraftVersion`: a Minecraft version as a string _(ex. `1.19.2` - Must be a subversion supported by Lunar Client)_
    -   [X] `primaryColor`: a hexademical color code that primarily distinguishes the server _(ex. `#00FFFF`)_
    -   [X] `secondaryColor`: a hexademical color code that accompanies the `primaryColor` of the server _(ex. `#FF0000`)_
    -   [X] `primaryRegion`: the primary region where your server operates in _(ex. `NA`)_
    -   [X] `regions`: a list of regions where you have servers located that service your players _(ex. `["NA", "EU", "AS"]`)_
    -   [X] `gameTypes`: a list of games that describe the content on your server _(ex. `["PvP", "UHC", "HCF"]`)_
    -   [ ] (optional) `primaryGameType`: the single game type that best represents your server, must be one of your `gameTypes` _(ex. `PvP`)_
    -   [X] `crossplay`: whether the server has support for Bedrock Edition players (through proxies such as [GeyserMC](https://geysermc.org/))
    -   [ ] (optional) `offline`: whether the server accepts offline connections
    -   [ ] (optional) `presentationVideo`: YouTube video ID (in slug) to server trailer / introduction _(ex. `7EV4cPuJvXE`)_
    -   [ ] (optional) `votingLinks`: an array of urls to your server's listing on voting websites _(ex. `["https://minecraft-mp.com/server-s179012"]`)_
    -   [ ] (optional) `website`: url of server website, must include URL schema (http:// or https://) _(ex. `https://www.your-server.com`)_
    -   [ ] (optional) `store`: url of server store, must include URL schema (http:// or https://) _(ex. `https://store.your-server.com`)_
    -   [ ] (optional) `wiki`: url of server wiki, must include URL schema (http:// or https://) _(ex. `https://wiki.your-server.com`)_
    -   [ ] (optional) `merch`: url of server merchanise site (if seperate from store), must include URL schema (http:// or https://) _(ex. `https://merch.your-server.com`)_

### Socials

-   [ ] (optional) `twitter`: username of twitter account without the @ _(ex. MyServer)_
-   [ ] (optional) `discord`: invite link to discord _(ex. https://discord.com/invite/4ceEJuH)_
-   [ ] (optional) `youtube`: slug or username of youtube channel _(ex. MyServer)_
-   [ ] (optional) `instagram`: username of instagram account _(ex. MyServer)_
-   [ ] (optional) `twitch`: username of twitch account _(ex. MyServer)_
-   [ ] (optional) `telegram`: slug of telegram group _(ex. MyServer)_
-   [ ] (optional) `reddit`: slug of subdreddit wtih 'r/' _(ex. MyServer)_
-   [ ] (optional) `tiktok`: username of tiktok account _(ex. MyServer)_
-   [ ] (optional) `facebook`: slug of facebook page _(ex. MyServer)_

### Compliance

-   [ ] (optional) `privacyPolicy`: url to your Privacy Policy _(ex. https://www.lunar.gg/privacy)_
-   [ ] (optional) `termsOfService`: url to your Terms of Service _(ex. https://www.lunar.gg/terms)_
-   [ ] (optional) `rules`: url to your Rules _(ex. https://www.lunar.gg/rules)_
-   [ ] (optional) `support`: url to your Support Site _(ex. https://www.lunar.gg/support)_

### Media:

#### Logo

-   [X] My logo is a `png` file.
-   [X] I have uploaded my logo to my server folder _(ex. `lunarnetwork`)_ and named it `logo.png`.
-   [X] My logo has a transparent background and is square (1:1 aspect ratio).
-   [X] My logo is at least `512` pixels in width and height.
-   [X] My logo is my own property and complies with relevant copyright/privacy laws.
-   [X] My logo is not upscaled from a smaller low quality image.

#### Background

-   [X] My background is a `png` file.
-   [X] I have uploaded my background to my server folder _(ex. `lunarnetwork`)_ and named it `background.png`.
-   [X] My background has an aspect ratio of 16:9.
-   [X] My background is atleast `1920` pixels in width and `1080` pixels in height (can be bigger, but must remain the same aspect ratio).
-   [X] My background contains relevant content pertaining to the server, is my own property, and complies with relevant copyright/privacy laws.
-   [X] My background doesn't contain any markings, text, or logos (unless part of a build).
