### PR TITLE
Added required flag to modpack schema

### DIFF
--- a/metadata.schema.json
+++ b/metadata.schema.json
@@ -136,6 +136,11 @@
                     "type": "string",
                     "description": "The Modpack ID on the given provider (Modrinth project ID or CurseForge mod ID)."
                 },
+                "required": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If true, the Modpack must be installed to join the server. The user is always prompted, and can only install it or cancel the join."
+                },
                 "recommendedVersion": {
                     "type": "string",
                     "description": "The recommended Modpack version. If blank, will use latest version."


### PR DESCRIPTION
adds `required` to the `modpack` block, defaulting to `false`. lets a server mark its modpack as mandatory to join rather than only recommended

the block is `additionalProperties: false`, so without the schema entry any metadata using `required` fails validation

### General:

-   [x] The pull request title is descriptive. _(ex. `Added Lunar Network`, not `Updated metadata.json`)_
-   [x] The pull request does not contain any unrelated commits. _(ex. commits from previous pull requests)_
