### PR TITLE
Fix nightly media upload failing with "Argument list too long"

### DIFF
--- a/.github/workflows/validate-upload.yml
+++ b/.github/workflows/validate-upload.yml
@@ -157,6 +157,14 @@ jobs:
 
       - name: Output Server Media
         run: |
+          # A dry run converts every server regardless, and its changed file
+          # list is too large to pass as a single argument.
+          if [ '${{ needs.changes.outputs.dry }}' = 'true' ]; then
+            set --
+          else
+            set -- --changed_files '${{ needs.changes.outputs.servers_files }}'
+          fi
+
           python .scripts/convert_media.py \
           --servers_dir servers \
           --inactive_file inactive.json \
@@ -167,8 +175,8 @@ jobs:
           --servers_banners_output .out/banners \
           --servers_wordmarks_output .out/wordmarks \
           --servers_assets_output .out/assets \
-          --changed_files '${{ needs.changes.outputs.servers_files }}' \
-          --dry_upload ${{ needs.changes.outputs.dry }}
+          --dry_upload '${{ needs.changes.outputs.dry }}' \
+          "$@"
         env:
           USE_ARGS: "true"
 


### PR DESCRIPTION
### Summary

The scheduled (`cron: 0 0 * * *`) run of this workflow has been dying instantly in **Output Server Media** with:

```
/opt/hostedtoolcache/Python/3.14.7/x64/bin/python: Argument list too long
```

On a `schedule` event `dorny/paths-filter` has no base to diff against, so it reports every `servers/**` file as changed and `servers_files` becomes a ~208 KB JSON array. Interpolating that into `--changed_files` exceeds Linux's 128 KB limit on a single argv string, so the step fails before Python starts — even though `convert_media.py` ignores `--changed_files` entirely when `--dry_upload` is true.

So: only pass `--changed_files` when it's actually used.

```sh
if [ "$dry" = 'true' ]; then set --; else set -- --changed_files "$servers_files"; fi
python .scripts/convert_media.py ... --dry_upload "$dry" "$@"
```

The huge value now only appears in the branch that isn't taken on a schedule event, so it's never expanded into argv. `--dry_upload` is also quoted, which is a no-op for the current `true`/`false` outputs but avoids an argparse error if the output is ever empty.

Effect: the nightly full re-upload of all media actually runs again. That matters beyond the red X — it's the safety net that backfills any server whose media upload was skipped, e.g. when a push run loses the index-freshness race and exits before converting media. `heeph`'s logo and background are currently 404 on the CDN for exactly that reason.

### General:

-   [x] The pull request title is descriptive. _(ex. `Added Lunar Network`, not `Updated metadata.json`)_
-   [x] The pull request does not contain any unrelated commits. _(ex. commits from previous pull requests)_

_The mapping / media / socials / compliance sections of the template don't apply — this is a CI-only change._


Link to Devin session: https://app.devin.ai/sessions/da04bd2313944f4ab57a3cb3e9898d27
Open in Devin Desktop: https://app.devin.ai/desktop/session/da04bd2313944f4ab57a3cb3e9898d27?variant=devin
Requested by: @colinmcdonald22