### PR TITLE
Isolate validation artifacts from the feedback checkout

### DIFF
--- a/.github/workflows/pr-feedback.yml
+++ b/.github/workflows/pr-feedback.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: pr-results
+          path: ${{ runner.temp }}/pr-results
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
@@ -43,6 +44,7 @@ jobs:
         run: python .scripts/post_pr_feedback.py
         env:
           BOT_PAT: ${{ secrets.BOT_PAT }}
+          RESULTS_FILE: ${{ runner.temp }}/pr-results/pr_results.json
           DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
           WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           WORKFLOW_RUN_HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}

--- a/.scripts/post_pr_feedback.py
+++ b/.scripts/post_pr_feedback.py
@@ -20,7 +20,7 @@ import requests
 
 API_ROOT = "https://api.github.com"
 READY_LABEL = "Ready for review"
-RESULTS_FILE = "pr_results.json"
+RESULTS_FILE = os.environ["RESULTS_FILE"]
 
 
 def gh_request(method: str, path: str, token: str, **kwargs) -> requests.Response:


### PR DESCRIPTION
Download validation results into a dedicated runner temporary directory and pass the JSON path to the feedback script. This keeps PR-supplied artifacts outside the trusted checkout used by the feedback job.

Validated locally: isolated artifact extraction, ready/error feedback, rejection of mismatched PR IDs, failed-download handling, Python syntax, and diff whitespace. GitHub requests were mocked; no live feedback actions were performed.

- [x] Descriptive title and no unrelated commits.
- Mapping/media checklist: not applicable; workflow-only fix.
