### PR TITLE
Use GITHUB_TOKEN for PR validation feedback

### DIFF
--- a/.github/workflows/pr-feedback.yml
+++ b/.github/workflows/pr-feedback.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Post validation feedback
         run: python .scripts/post_pr_feedback.py
         env:
-          BOT_PAT: ${{ secrets.BOT_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RESULTS_FILE: ${{ runner.temp }}/pr-results/pr_results.json
           DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
           WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}

--- a/.scripts/post_pr_feedback.py
+++ b/.scripts/post_pr_feedback.py
@@ -113,7 +113,7 @@ def build_review_body(errors: dict) -> str:
 
 
 def main() -> None:
-    token = os.environ["BOT_PAT"]
+    token = os.environ["GITHUB_TOKEN"]
     repo = os.environ["GITHUB_REPOSITORY"]
     head_sha = os.environ.get("WORKFLOW_RUN_HEAD_SHA", "")
     head_owner = os.environ.get("WORKFLOW_RUN_HEAD_OWNER", "")


### PR DESCRIPTION
Use the workflow’s built-in `GITHUB_TOKEN` for PR validation feedback instead of the stored `BOT_PAT`. The workflow passes it to `post_pr_feedback.py`, which continues to update the “Ready for review” label and submit request-changes reviews with its existing permissions.

Validation: Actionlint passed for the feedback and approval workflows; Python syntax and `git diff --check` passed. Live label updates and request-changes submission with `GITHUB_TOKEN` still need verification after merge because feedback runs from the default branch. Keep the existing PAT and secret until that verification succeeds.

### General

- [x] The pull request title is descriptive.
- [x] The pull request does not contain unrelated commits.

Mapping, socials, compliance, and media checklists are not applicable to this workflow-only change.
